### PR TITLE
[bhkayyar] Refactor I2C write and eliminate conversion warnings

### DIFF
--- a/src/SparkFun_Qwiic_Relay.cpp
+++ b/src/SparkFun_Qwiic_Relay.cpp
@@ -5,7 +5,6 @@
   Date: July 2019 
   License: This code is public domain but you buy me a beer if you use this and 
   we meet someday (Beerware license).
-
   Feel like supporting our work? Buy a board from SparkFun!
  */
 
@@ -32,13 +31,13 @@ bool Qwiic_Relay::begin( TwoWire &wirePort )
 // This function turns the single relay board on. 
 void Qwiic_Relay::turnRelayOn()
 {
-  _writeCommandOn(TURN_RELAY_ON);
+  _writeCommand(TURN_RELAY_ON);
 }
 
 // This function turns the single relay board off. 
 void Qwiic_Relay::turnRelayOff() 
 {
-  _writeCommandOff(TURN_RELAY_OFF);
+  _writeCommand(TURN_RELAY_OFF);
 }
 
 // This function gives toggle functionality to the single relay. First the
@@ -57,7 +56,7 @@ void Qwiic_Relay::toggleRelay()
 // whether on: 1 or off: 0;
 uint8_t Qwiic_Relay::getState()
 {
-  uint8_t status =  _readCommand(MYSTATUS);
+  uint8_t status = _readCommand(MYSTATUS);
   return status; 
 }
 
@@ -86,13 +85,13 @@ uint8_t Qwiic_Relay::getSlowPWM(uint8_t relay)
 // This function turns the given relay on.
 void Qwiic_Relay::turnRelayOn(uint8_t relay)
 {
-  _writeCommandOn(relay);
+  _setRelayStatus(relay, QUAD_RELAY_ON);
 }
 
 // This function turns the given relay off.
 void Qwiic_Relay::turnRelayOff(uint8_t relay)
 {
-  _writeCommandOff(relay);
+  _setRelayStatus(relay, QUAD_RELAY_OFF);
 }
 
 // This function toggles the given relay. If the relay is on then it will turn
@@ -100,36 +99,36 @@ void Qwiic_Relay::turnRelayOff(uint8_t relay)
 void Qwiic_Relay::toggleRelay(uint8_t relay)
 {
   if (relay == RELAY_ONE)
-    _writeCommandToggle(TOGGLE_RELAY_ONE);
+    _writeCommand(TOGGLE_RELAY_ONE);
   else if (relay == RELAY_TWO)
-    _writeCommandToggle(TOGGLE_RELAY_TWO);
+    _writeCommand(TOGGLE_RELAY_TWO);
   else if (relay == RELAY_THREE)
-    _writeCommandToggle(TOGGLE_RELAY_THREE);
+    _writeCommand(TOGGLE_RELAY_THREE);
   else if(relay == RELAY_FOUR)
-    _writeCommandToggle(TOGGLE_RELAY_FOUR);
+    _writeCommand(TOGGLE_RELAY_FOUR);
   else 
     return;
+}
+
+// This function for the SparkFun Quad Relay, toggles all relays on the
+// board. 
+void Qwiic_Relay::toggleAllRelays()
+{
+  _writeCommand(TOGGLE_ALL);
 }
 
 // This function for the SparkFun Quad Relay, turns on all relays on the
 // board. 
 void Qwiic_Relay::turnAllRelaysOn()
 {
-  _writeCommandOn(TURN_ALL_ON);
+  _writeCommand(TURN_ALL_ON);
 }
 
 // This function for the SparkFun Quad Relay, turns off all relays on the
 // board. 
 void Qwiic_Relay::turnAllRelaysOff()
 {
-  _writeCommandOff(TURN_ALL_OFF);
-}
-
-// This function for the SparkFun Quad Relay, turns off all relays on the
-// board. 
-void Qwiic_Relay::toggleAllRelays()
-{
-  _writeCommandOn(TOGGLE_ALL);
+  _writeCommand(TURN_ALL_OFF);
 }
 
 // This function for the SparkFun Quad Relay, gets the status of the relay:
@@ -139,13 +138,13 @@ uint8_t Qwiic_Relay::getState(uint8_t relay)
 
   uint8_t status; 
   if(relay == RELAY_ONE)
-    status =  _readCommand(RELAY_ONE_STATUS);
+    status = _readCommand(RELAY_ONE_STATUS);
   else if(relay == RELAY_TWO)
-    status =  _readCommand(RELAY_TWO_STATUS);
+    status = _readCommand(RELAY_TWO_STATUS);
   else if(relay == RELAY_THREE)
-    status =  _readCommand(RELAY_THREE_STATUS);
+    status = _readCommand(RELAY_THREE_STATUS);
   else if(relay == RELAY_FOUR)
-    status =  _readCommand(RELAY_FOUR_STATUS);
+    status = _readCommand(RELAY_FOUR_STATUS);
   else
     return INCORR_PARAM;
   
@@ -163,14 +162,7 @@ bool Qwiic_Relay::changeAddress(uint8_t newAddress)
   if (newAddress < 0x07 || newAddress > 0x78) // Range of legal addresses
         return false; 
 
-  _i2cPort->beginTransmission( _address);  
-  _i2cPort->write(ADDRESS_LOCATION);  
-  _i2cPort->write(newAddress);  
-
-  if(!_i2cPort->endTransmission())
-    return true; 
-  else
-    return false; 
+  return (_writeCommand(ADDRESS_LOCATION));
 
 }
 
@@ -190,170 +182,71 @@ bool Qwiic_Relay::_writeAddress(uint8_t addressToWrite, uint8_t value)
   }
   
 }
-// This function handles I-squared-C write commands for turning the relays on. 
+
+// This function handles I-squared-C write commands for changing a relay's state. 
 // The quad relay relies on the current state of the relay to determine whether
 // or not to turn the respective relay on (or off) and so the current state of
-// the relay is checked before attempting to send a command. 
-void Qwiic_Relay::_writeCommandOn(uint8_t _command)
+// the relay is checked before attempting to send a command.
+void Qwiic_Relay::_setRelayStatus(uint8_t _relay, uint8_t _desiredState)
 {
-
-  uint8_t _status; 
-  if (_command == RELAY_ONE){
-    _status = _readCommand(RELAY_ONE_STATUS);
-    if( _status == QUAD_RELAY_ON ){ // Is it on? Then....
-      return; // Do nothing....
-    }
-    else { // Off?
-      _i2cPort->beginTransmission(_address); // Start communication.
-      _i2cPort->write(TOGGLE_RELAY_ONE); // Toggle it on....
-      _i2cPort->endTransmission(); // End communcation.
-    }
-  }
-  // Repeat for relay two....
-  else if (_command == RELAY_TWO){
-    _status = _readCommand(RELAY_TWO_STATUS);
-    if( _status == QUAD_RELAY_ON ){
-      return;
-    }
-    else {
-      _i2cPort->beginTransmission(_address);
-      _i2cPort->write(TOGGLE_RELAY_TWO); 
-      _i2cPort->endTransmission(); 
-    }
-  }
-  // Relay three..
-  else if (_command == RELAY_THREE){
-    _status = _readCommand(RELAY_THREE_STATUS);
-    if( _status == QUAD_RELAY_ON ){
-      return;
-    }
-    else {
-      _i2cPort->beginTransmission(_address); 
-      _i2cPort->write(TOGGLE_RELAY_THREE);
-      _i2cPort->endTransmission(); 
-    }
-  }
-  // Relay four.... 
-  else if (_command == RELAY_FOUR){
-    _status = _readCommand(RELAY_FOUR_STATUS);
-    if( _status == QUAD_RELAY_ON ){
-      return;
-    }
-    else {
-      _i2cPort->beginTransmission(_address);
-      _i2cPort->write(TOGGLE_RELAY_FOUR);
-      _i2cPort->endTransmission(); 
-    }
-  }
-  // If it's not 1-4 then it must be for the single relay....
-  else {
-    _i2cPort->beginTransmission(_address);
-    _i2cPort->write(_command);
-    _i2cPort->endTransmission(); 
-  }
-     
-}
-
-// This function handles I-squared-C write commands for toggling the relays from their
-// current state. If the relay is on then it will be turned off and vice versa. 
-void Qwiic_Relay::_writeCommandToggle(uint8_t _command){
-
-    _i2cPort->beginTransmission(_address);
-    _i2cPort->write(_command);
-    _i2cPort->endTransmission(); 
-
-}
-
-// This function handles I-squared-C write commands for turning the relays off. 
-// The quad relay relies on the current state of the relay to determine whether
-// or not to turn the respective relay off (or on) and so the current state of
-// the relay is checked before attempting to toggle it.
-void Qwiic_Relay::_writeCommandOff(uint8_t _command)
-{
-
   uint8_t _status;
-  if( _command == RELAY_ONE ){
+
+  if (_relay == RELAY_ONE){
     _status = _readCommand(RELAY_ONE_STATUS);
-    if( _status == QUAD_RELAY_OFF ){ // Is the board off?
-      return; // Do nothing...
-    }
-    else { // Then it must be on...
-      _i2cPort->beginTransmission(_address); // Start communication.
-      _i2cPort->write(TOGGLE_RELAY_ONE); // Toggle it off....
-      _i2cPort->endTransmission(); // End communcation.
+    if( _status != _desiredState){ // Toggle relay if it doesn't match the desired state
+      _writeCommand(TOGGLE_RELAY_ONE);
     }
   }
-  // Repeat for relay two....
-  else if( _command == RELAY_TWO ){
+  else if (_relay == RELAY_TWO){
     _status = _readCommand(RELAY_TWO_STATUS);
-    if( _status == QUAD_RELAY_OFF ){
-      return;
-    }
-    else {
-      _i2cPort->beginTransmission(_address); // Start communication.
-      _i2cPort->write(TOGGLE_RELAY_TWO); 
-      _i2cPort->endTransmission(); // End communcation.
+    if( _status != _desiredState){ // Repeat for all four relays
+      _writeCommand(TOGGLE_RELAY_TWO);
     }
   }
-  // Relay three...
-  else if( _command == RELAY_THREE ){
+  else if (_relay == RELAY_THREE){
     _status = _readCommand(RELAY_THREE_STATUS);
-    if( _status == QUAD_RELAY_OFF ){
-      return;
-    }
-    else {
-      _i2cPort->beginTransmission(_address); // Start communication.
-      _i2cPort->write(TOGGLE_RELAY_THREE);
-      _i2cPort->endTransmission(); // End communcation.
+    if( _status != _desiredState){ 
+      _writeCommand(TOGGLE_RELAY_THREE);
     }
   }
-  // Relay four....
-  else if( _command == RELAY_FOUR ){
+  else if (_relay == RELAY_FOUR){
     _status = _readCommand(RELAY_FOUR_STATUS);
-    if( _status == QUAD_RELAY_OFF ){
-      return;
-    }
-    else {
-      _i2cPort->beginTransmission(_address); // Start communication.
-      _i2cPort->write(TOGGLE_RELAY_FOUR);
-      _i2cPort->endTransmission(); // End communcation.
+    if( _status != _desiredState){ 
+      _writeCommand(TOGGLE_RELAY_FOUR);
     }
   }
-  // If it's not 1-4 then it must be for the single relay...
-  else {
-    _i2cPort->beginTransmission(_address);
-    _i2cPort->write(_command);
-    _i2cPort->endTransmission(); 
-  }
-     
 }
 
 // This function requests information from the product with a simple
 // I-squared-C transaction.
 uint8_t Qwiic_Relay::_readCommand(uint8_t _command)
 {
+  _writeCommand(_command);
 
-  _i2cPort->beginTransmission(_address); 
-  _i2cPort->write(_command);
-  _i2cPort->endTransmission();
-
-  _i2cPort->requestFrom(_address, 1);  
+  _i2cPort->requestFrom(_address, (uint8_t)1);
   uint8_t status = _i2cPort->read();
   return(status);
 
 }
 
-// The function reads thee version number of the Single Quad Relay.
+// The function reads the version number of the Single Quad Relay.
 float Qwiic_Relay::_readVersion(uint8_t _command)
 {
-  _i2cPort->beginTransmission(_address); 
-  _i2cPort->write(_command); 
-  _i2cPort->endTransmission();
+  _writeCommand(_command);
 
-  _i2cPort->requestFrom(_address, 2); 
+  _i2cPort->requestFrom(_address, (uint8_t)2); 
   float _versValue = _i2cPort->read();
   _versValue += (float)_i2cPort->read() / 10.0 ;
   return(_versValue);
   
 }
 
+// This function writes information to the product with a simple
+// I-squared-C transaction.
+bool Qwiic_Relay::_writeCommand(uint8_t _command)
+{
+  _i2cPort->beginTransmission(_address); 
+  _i2cPort->write(_command);
+  return (_i2cPort->endTransmission() == 0);
+
+}

--- a/src/SparkFun_Qwiic_Relay.cpp
+++ b/src/SparkFun_Qwiic_Relay.cpp
@@ -5,6 +5,7 @@
   Date: July 2019 
   License: This code is public domain but you buy me a beer if you use this and 
   we meet someday (Beerware license).
+  
   Feel like supporting our work? Buy a board from SparkFun!
  */
 

--- a/src/SparkFun_Qwiic_Relay.h
+++ b/src/SparkFun_Qwiic_Relay.h
@@ -142,27 +142,21 @@ class Qwiic_Relay
     //This function writes a value to an address in the relay, used to set PWM values
     bool _writeAddress(uint8_t address, uint8_t value);
 
-    // This function handles I-squared-C write commands for turning the relays on. 
+    // This function writes a command to the product with a simple
+    // I-squared-C transaction.
+    bool _writeCommand(uint8_t _command);
+
+    // This function handles I-squared-C write commands for changing a relay's state. 
     // The quad relay relies on the current state of the relay to determine whether
     // or not to turn the respective relay on (or off) and so the current state of
-    // the relay is checked before attempting to send a command. 
-    void _writeCommandOn(uint8_t _command);
-
-    // This function handles I-squared-C write commands for turning the relays off. 
-    // The quad relay relies on the current state of the relay to determine whether
-    // or not to turn the respective relay off (or on) and so the current state of
-    // the relay is checked before attempting to toggle it.
-    void _writeCommandOff(uint8_t _command);
-
-    // This command sends the I-squared-C write command to toggle relays from their
-    // current state.
-    void _writeCommandToggle(uint8_t _command);
+    // the relay is checked before attempting to send a command.
+    void _setRelayStatus(uint8_t _relay, uint8_t _desiredState);
 
     // This function requests information from the product with a simple
     // I-squared-C transaction.
     uint8_t _readCommand(uint8_t _command);
 
-    // The function reads thee version number of the Single Quad Relay.
+    // The function reads the version number of the Single Quad Relay.
     float _readVersion(uint8_t _command);
 
     TwoWire *_i2cPort;


### PR DESCRIPTION
There are two major changes in this PR:

1. Refactor the I2C writes for the Qwiic quad relay to remove repeated code. I did this by writing a common function, `_writeCommand`, that just takes a general command and writes it to the specified address. I also added a second function, `_setRelayStatus` to replace both the `_writeCommandOn` and `_writeCommandOff` functions by generalizing the desired state of the relay.

2. Eliminate conversion warnings: there were compile-time warnings about conversions between _uint8_t_ and _int_ in the `_i2cPort->requestFrom` calls. I eliminated these by adding an explicit cast to _uint8_t_ for the constant # of bytes to request from the device.

**Important**: I'm unable to test these changes because I bricked by Qwiic quad-relay board. I know that this code compiles without warnings or errors, but I was hoping SparkFun might have a board handy to test these changes.