### PR TITLE
Fix for #3 that still supports quad relays and updating address change example

### DIFF
--- a/Examples/Example6_Change_I2C_Address/Example6_Change_I2C_Address.ino
+++ b/Examples/Example6_Change_I2C_Address/Example6_Change_I2C_Address.ino
@@ -19,20 +19,25 @@
 #include <Wire.h>
 #include "SparkFun_Qwiic_Relay.h"
 
-// All available product addresses labeled below. Close the onboard jumpers if
+// All default product addresses labeled below. Close the onboard jumpers if
 // you want to access the alternate addresses. 
 #define SINGLE_DEFAULT_ADDR 0x18 // Alternate jumper address 0x19
 #define QUAD_DEFAULT_ADDR 0x6D // Alternate jumper address 0x6C
 
+// There is a not so limited but still limited range of
+// addresses that are available to you 0x07 -> 0x78.
+#define NEW_ADDR 0x09 // Put the new address you want here
+#define IS_SINGLE_RELAY false // Change to true if using Single Relay
 
 // After changing the address you'll need to apply that address to a new
 // instance of the Qwiic_Relay class: "Qwiic_Relay relay(YOUR_NEW_ADDRESS_HERE)".
-Qwiic_Relay relay(QUAD_DEFAULT_ADDR); // Change to Single Relay Address if using Quad Relay
+Qwiic_Relay relay(QUAD_DEFAULT_ADDR); // Change to Single Relay Address if using Single Relay
 
 void setup()
 {
   Wire.begin(); 
   Serial.begin(115200);
+  delay(1000);
   
   // Let's see.....
   if(relay.begin())
@@ -40,9 +45,7 @@ void setup()
   else
     Serial.println("Check connections to Qwiic Relay.");
 
-  // There is a not so limited but still limited range of
-  // addresses that are available to you 0x07 -> 0x78.
-  if(relay.changeAddress(0x09)) // Put the address you want here. 
+  if(relay.changeAddress(NEW_ADDR, IS_SINGLE_RELAY))
     Serial.println("Address changed successfully."); 
   else
     Serial.println("Address change failed...");

--- a/src/SparkFun_Qwiic_Relay.cpp
+++ b/src/SparkFun_Qwiic_Relay.cpp
@@ -157,14 +157,18 @@ uint8_t Qwiic_Relay::getState(uint8_t relay)
 
 // This function changes the I-squared-C address of the Qwiic RFID. The address
 // is written to the memory location in EEPROM that determines its address.
-bool Qwiic_Relay::changeAddress(uint8_t newAddress) 
+bool Qwiic_Relay::changeAddress(uint8_t newAddress, bool isSingleRelay = false)
 {
 
   if (newAddress < 0x07 || newAddress > 0x78) // Range of legal addresses
         return false; 
 
-  _i2cPort->beginTransmission( _address);  
-  _i2cPort->write(ADDRESS_LOCATION);  
+  _i2cPort->beginTransmission( _address);
+  if (isSingleRelay) {
+    _i2cPort->write(SINGLE_CHANGE_ADDRESS);
+  } else {
+    _i2cPort->write(QUAD_CHANGE_ADDRESS);
+  }
   _i2cPort->write(newAddress);  
 
   if(!_i2cPort->endTransmission())

--- a/src/SparkFun_Qwiic_Relay.h
+++ b/src/SparkFun_Qwiic_Relay.h
@@ -65,7 +65,8 @@ enum SF_SINGLE_RELAY_STATUS {
 #define DUAL_SSR_DEFAULT_ADDRESS   0x0A
 #define DUAL_SSR_ALTERNATE_ADDRESS 0x0B
 
-#define ADDRESS_LOCATION 0xC7
+#define QUAD_CHANGE_ADDRESS   0xC7
+#define SINGLE_CHANGE_ADDRESS 0x03
 #define INCORR_PARAM     0xFF
 
 class Qwiic_Relay
@@ -133,7 +134,7 @@ class Qwiic_Relay
 
     // This function changes the I-squared-C address of the Qwiic RFID. The address
     // is written to the memory location in EEPROM that determines its address.
-    bool changeAddress(uint8_t newAddress);
+    bool changeAddress(uint8_t newAddress, bool isSingleRelay);
 
   private:
 


### PR DESCRIPTION
Fix for issue #3, the changeAddress() function doesn't currently work for single relays because they use different i2c commands

Tested on a single relay, and it should also work on a quad and other relays since it leaves the address unchanged by default.